### PR TITLE
fixed scopes parsing in refresh token

### DIFF
--- a/src/grants/refresh_token.grant.ts
+++ b/src/grants/refresh_token.grant.ts
@@ -19,7 +19,7 @@ export class RefreshTokenGrant extends AbstractGrant {
 
     const user = oldToken.user;
 
-    const scopes = await this.validateScopes(this.getRequestParameter("scope", request, oldToken.scopes));
+    const scopes = await this.validateScopes(this.getRequestParameter("scope", request, oldToken.scopes.map(s=>s.name)));
 
     scopes.forEach(scope => {
       if (!oldToken.scopes.map(scope => scope.name).includes(scope.name)) {


### PR DESCRIPTION
fixed "The requested scope is invalid, unknown, or malformed: Check the `[object Object]` scope(s)" erro while generating refresh token without "scope" claims in the request